### PR TITLE
Fix build_boundary: handle inner boundaries that touches outer at one point

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
   include:
   - rust: nightly
     before_script: rustup component add rustfmt-preview
-    script: cargo fmt --all -- --write-mode diff
+    script: cargo fmt --all -- --check
   - rust: stable
     script:
     - cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osm_boundaries_utils"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["dt.ro <dt.ro@canaltp.fr>"]
 description = "utilities to help reading OpenStreetMap boundaries in rust."
 repository = "https://github.com/QwantResearch/osm_boundaries_utils_rs"

--- a/src/boundaries.rs
+++ b/src/boundaries.rs
@@ -585,6 +585,12 @@ fn test_build_two_boundaries_with_two_holes() {
 fn test_build_inner_touching_outer_at_one_point() {
     use geo::algorithm::area::Area;
     let mut builder = osm_builder::OsmBuilder::new();
+
+    /*
+        A single polygon with an inner square touching at a single point.
+        Inspired from the first 'valid' figure on
+        https://shapely.readthedocs.io/en/latest/manual.html#Polygon
+    */
     let rel_id = builder
         .relation()
         .outer(vec![

--- a/src/osm_builder.rs
+++ b/src/osm_builder.rs
@@ -14,7 +14,8 @@ pub struct Relation<'a> {
 impl<'a> Relation<'a> {
     pub fn outer(&mut self, coords: Vec<(Point<f64>, Option<String>)>) -> &'a mut Relation {
         let id = self.builder.way(coords);
-        if let &mut osmpbfreader::OsmObj::Relation(ref mut rel) = self.builder
+        if let &mut osmpbfreader::OsmObj::Relation(ref mut rel) = self
+            .builder
             .objects
             .get_mut(&self.relation_id.into())
             .unwrap()
@@ -31,7 +32,8 @@ impl<'a> Relation<'a> {
 impl<'a> Relation<'a> {
     pub fn inner(&mut self, coords: Vec<(Point<f64>, Option<String>)>) -> &'a mut Relation {
         let id = self.builder.way(coords);
-        if let &mut osmpbfreader::OsmObj::Relation(ref mut rel) = self.builder
+        if let &mut osmpbfreader::OsmObj::Relation(ref mut rel) = self
+            .builder
             .objects
             .get_mut(&self.relation_id.into())
             .unwrap()


### PR DESCRIPTION
To associate each inner ring to an outer ring, we currently use the `contains` method from rust-geo. As a consequence an inner boundary that touches another boundary is not associated with any outer.

As a fix, this PR suggests replacing `contains` with a less strict check, that should be enough to find the correct outer among all outer rings in the multipolygon. I tried to explain this as clearly as possible in the code comments, but maybe we could find a better formulation.