### PR TITLE
Support osmpbfreader-rs 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ readme = "README.md"
 
 [dependencies]
 log = "0.4"
-osmpbfreader = "0.13"
+osmpbfreader = "0.14"
 geo-types = "^0.6"
 geo = "0.14"

--- a/src/boundaries.rs
+++ b/src/boundaries.rs
@@ -219,7 +219,7 @@ pub fn build_boundary_parts<T: Borrow<osmpbfreader::OsmObj>>(
                     warn!(
                         "boundary: relation/{} ({}): unclosed polygon, dist({:?}, {:?}) = {}",
                         relation.id.0,
-                        relation.tags.get("name").map_or("", String::as_str),
+                        relation.tags.get("name").map_or("", |s| &s),
                         poly_geom.first().unwrap().id,
                         poly_geom.last().unwrap().id,
                         distance
@@ -246,15 +246,15 @@ fn test_build_boundary_empty() {
     };
     relation.refs.push(osmpbfreader::Ref {
         member: osmpbfreader::WayId(4).into(),
-        role: "outer".to_string(),
+        role: "outer".into(),
     });
     relation.refs.push(osmpbfreader::Ref {
         member: osmpbfreader::WayId(65).into(),
-        role: "outer".to_string(),
+        role: "outer".into(),
     });
     relation.refs.push(osmpbfreader::Ref {
         member: osmpbfreader::WayId(22).into(),
-        role: "".to_string(),
+        role: "".into(),
     });
     assert!(build_boundary(&relation, &objects).is_none());
 }

--- a/src/osm_builder.rs
+++ b/src/osm_builder.rs
@@ -3,7 +3,7 @@ use geo_types::Point;
 use std::collections::BTreeMap;
 
 pub fn named_node(lon: f64, lat: f64, name: &'static str) -> (Point<f64>, Option<String>) {
-    (Point::new(lon, lat), Some(name.to_string()))
+    (Point::new(lon, lat), Some(name.into()))
 }
 
 pub struct Relation<'a> {
@@ -21,7 +21,7 @@ impl<'a> Relation<'a> {
             .unwrap()
         {
             rel.refs.push(osmpbfreader::Ref {
-                role: "outer".to_string(),
+                role: "outer".into(),
                 member: id.into(),
             });
         }
@@ -39,7 +39,7 @@ impl<'a> Relation<'a> {
             .unwrap()
         {
             rel.refs.push(osmpbfreader::Ref {
-                role: "inner".to_string(),
+                role: "inner".into(),
                 member: id.into(),
             });
         }


### PR DESCRIPTION
The latest version of osmpbfreader-rs switched internally to [smartstring](https://crates.io/crates/smartstring) to handle OSM tags. It requires some minor adaptions to the keep compatibility with v0.14.