### PR TITLE
Fix build_boundary_part for touching rings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: rust
 cache: cargo
 matrix:
   include:
-  - rust: nightly
-    before_script: rustup component add rustfmt-preview
-    script: cargo fmt --all -- --check
   - rust: stable
+    before_script:
+    - rustup component add rustfmt
     script:
+    - cargo fmt --all -- --check
     - cargo test
     after_success:
     - |-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,4 +7,4 @@ extern crate osmpbfreader;
 mod boundaries;
 pub mod osm_builder;
 
-pub use boundaries::build_boundary;
+pub use crate::boundaries::build_boundary;

--- a/src/osm_builder.rs
+++ b/src/osm_builder.rs
@@ -14,7 +14,7 @@ pub struct Relation<'a> {
 impl<'a> Relation<'a> {
     pub fn outer(&mut self, coords: Vec<(Point<f64>, Option<String>)>) -> &'a mut Relation {
         let id = self.builder.way(coords);
-        if let &mut osmpbfreader::OsmObj::Relation(ref mut rel) = self
+        if let osmpbfreader::OsmObj::Relation(ref mut rel) = self
             .builder
             .objects
             .get_mut(&self.relation_id.into())
@@ -32,7 +32,7 @@ impl<'a> Relation<'a> {
 impl<'a> Relation<'a> {
     pub fn inner(&mut self, coords: Vec<(Point<f64>, Option<String>)>) -> &'a mut Relation {
         let id = self.builder.way(coords);
-        if let &mut osmpbfreader::OsmObj::Relation(ref mut rel) = self
+        if let osmpbfreader::OsmObj::Relation(ref mut rel) = self
             .builder
             .objects
             .get_mut(&self.relation_id.into())


### PR DESCRIPTION
This is based on an old branch I never took the time to clean up.  
It solves a subtle issue about boundaries composed of multiple outer rings that touch at a single point.  
For example in Austria: https://www.openstreetmap.org/relation/16239#map=14/47.5656/10.4596

Depending on the order of the ways in the OSM relation, in some cases only 1 ring was built with duplicated nodes in it, whereas two distinct polygons are expected.

This new implementation keeps track of the added nodes while iterating on the boundary parts, to extract minimal rings.