### PR TITLE
Ignore ring with less than 3 nodes when iterating over boundary parts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osm_boundaries_utils"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["dt.ro <dt.ro@canaltp.fr>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 description = "utilities to help reading OpenStreetMap boundaries in rust."
 repository = "https://github.com/QwantResearch/osm_boundaries_utils_rs"

--- a/src/boundaries.rs
+++ b/src/boundaries.rs
@@ -217,7 +217,14 @@ pub fn build_boundary_parts<T: Borrow<osmpbfreader::OsmObj>>(
                         .enumerate()
                         .map(|(i, n)| (n.id, i))
                         .collect();
-                    append_ring(&ring);
+                    if ring.len() >= 3 {
+                        append_ring(&ring);
+                    } else {
+                        debug!(
+                            "Ignored ring with less than 3 nodes in relation:{} at node:{}",
+                            relation.id.0, n.id.0
+                        );
+                    }
                 }
                 node_to_idx.insert(n.id, added_nodes.len());
                 added_nodes.push(n);


### PR DESCRIPTION
### Why
Due to mapping errors, some ways may contain repeated nodes (A->B->B->C), or repeated segments (A->B->A->C).  
In such a case, the MultiPolygon composed of rings with 1 or 2 points is considered invalid, and in many contexts it will not be processed correctly. 

For example in Cosmogony, such a geometry fails to be converted to a Geos object: 
```
Invalid geometry, impossible to create a LinearRing, A LinearRing must have at least 3 coordinates
```