### PR TITLE
update to osmpbfreader 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osm_boundaries_utils"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["dt.ro <dt.ro@canaltp.fr>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 description = "utilities to help reading OpenStreetMap boundaries in rust."
 repository = "https://github.com/Qwant/osm_boundaries_utils_rs"
@@ -10,6 +10,6 @@ readme = "README.md"
 
 [dependencies]
 log = "0.4"
-osmpbfreader = "0.14"
+osmpbfreader = "0.15"
 geo-types = "^0.7"
 geo = "0.18"


### PR DESCRIPTION
Ok, so I couldn't stand the 50Go target dir in mimir anymore, so I started the crusade of dependency optimizations. I started with [cargo udeps](https://crates.io/crates/cargo-udeps/0.1.24) and I am currently trying to fix all warnings raised by [cargo audit](https://docs.rs/cargo-audit/0.15.1/cargo_audit/).

In this repository there is a single outdated dependency (osmpbfreader 0.14) which depends on a yanked package (self_cell 0.8).