### PR TITLE
feat: bump 'osmpbfreader:0.16'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ readme = "README.md"
 
 [dependencies]
 log = "0.4"
-osmpbfreader = "0.15"
+osmpbfreader = "0.16"
 geo-types = "^0.7"
 geo = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osm_boundaries_utils"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["dt.ro <dt.ro@canaltp.fr>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 description = "utilities to help reading OpenStreetMap boundaries in rust."
 repository = "https://github.com/Qwant/osm_boundaries_utils_rs"


### PR DESCRIPTION
`osmpbfreader` fixes a bug with `smartstring:1.0.0` which doesn't work with `rustc:1.67.0`.
See https://github.com/bodil/smartstring/issues/38

`smartstring:1.0.1` fixes the problem, version which have been released into `osmpbfreader:0.16.0`.

See https://github.com/TeXitoi/osmpbfreader-rs/issues/44 and the fix https://github.com/TeXitoi/osmpbfreader-rs/pull/45